### PR TITLE
Ripple

### DIFF
--- a/blockchain-scrapers/Dockerfile-xrp
+++ b/blockchain-scrapers/Dockerfile-xrp
@@ -1,0 +1,15 @@
+FROM golang:latest as build
+
+WORKDIR $GOPATH/src/
+
+COPY . .
+
+WORKDIR $GOPATH/src/github.com/diadata-org/api-golang/blockchain-scrapers/cmd/xrp
+
+RUN go install
+
+FROM gcr.io/distroless/base
+
+COPY --from=build /go/bin/xrp /bin/xrp
+
+CMD ["xrp"]

--- a/blockchain-scrapers/cmd/xrp/xrp.go
+++ b/blockchain-scrapers/cmd/xrp/xrp.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/eristoddle/api-golang/dia"
+	"github.com/diadata-org/api-golang/dia"
 )
 
 type Response struct {

--- a/blockchain-scrapers/cmd/xrp/xrp.go
+++ b/blockchain-scrapers/cmd/xrp/xrp.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/eristoddle/api-golang/dia"
+)
+
+type Response struct {
+	Result string `json:"result"`
+	Count  int    `json:"count"`
+	Marker string `json:"marker"`
+	Row    []Row  `json:"rows"`
+}
+
+type Row struct {
+	Date          string `json:"date"`
+	Total         string `json:"total"`
+	Distributed   string `json:"distributed"`
+	Undistributed string `json:"undistributed"`
+	Escrowed      string `json:"escrowed"`
+}
+
+const endpoint = "https://data.ripple.com/v2/network/xrp_distribution?limit=1&descending=true"
+const symbol = "XRP"
+
+func main() {
+	config := dia.GetConfigApi()
+	if config == nil {
+		panic("Couldnt load config")
+	}
+	client := dia.NewClient(config)
+	if client == nil {
+		panic("Couldnt load client")
+	}
+	prevResult := 0.0
+	for {
+		response, err := http.Get(endpoint)
+		if err == nil {
+			responseData, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				log.Println("Failed to retrieve xrp supply: ", err)
+			}
+			var responseObject Response
+			uerr := json.Unmarshal(responseData, &responseObject)
+			if uerr != nil {
+				fmt.Println("There was an response unmarshalling error:", err)
+			}
+			distributed := responseObject.Row[0].Distributed
+			result, cerr := strconv.ParseFloat(distributed, 64)
+			if cerr != nil {
+				fmt.Println("There was an integer conversion error:", err)
+			}
+			fmt.Printf("Symbol: %s ; circulatingSupply: %f\n", symbol, result)
+			if prevResult != result {
+				client.SendSupply(&dia.Supply{
+					Symbol:            symbol,
+					CirculatingSupply: result,
+				})
+				prevResult = result
+			}
+		} else {
+			log.Println("Err communicating with node:", err)
+		}
+		time.Sleep(time.Second * 10)
+		// time.Sleep(time.Hour * 1)
+	}
+
+}

--- a/blockchain-scrapers/docker-compose.yml
+++ b/blockchain-scrapers/docker-compose.yml
@@ -98,6 +98,18 @@ services:
         max-size: "50m"
     secrets:
       - api_diadata
+  xrp:
+    build:
+      context: ../../../..
+      dockerfile: github.com/diadata-org/api-golang/blockchain-scrapers/Dockerfile-xrp
+    image: ${DOCKER_HUB_LOGIN}/blockchain-scrapers_xrp
+    networks:
+      - scrapers-network
+    logging:
+      options:
+        max-size: "50m"
+    secrets:
+      - api_diadata
 volumes:
   bitcoin:
 


### PR DESCRIPTION
I will have to use the official Ripple api for this one. The open source rippled package does not have the new Data API V2 which has the distribution API call shown here: https://developers.ripple.com/data-api-v2-tool.html#get-xrp-distribution. The circulating supply value is the distribution value. Details on the official api being the only place with the V2 Data API: https://github.com/ripple/rippled-historical-database. I actually created my own image: https://github.com/eristoddle/docker-rippled of the latest rippled version, but it only has the ws and old json-rpc api's. From what I can tell the distribution only seems to change once a week, but I will have the script run every 10 seconds and only hit the DIA api when the number changes like the other scripts.