### PR TITLE
Stellar

### DIFF
--- a/blockchain-scrapers/Dockerfile-xlm
+++ b/blockchain-scrapers/Dockerfile-xlm
@@ -1,0 +1,15 @@
+FROM golang:latest as build
+
+WORKDIR $GOPATH/src/
+
+COPY . .
+
+WORKDIR $GOPATH/src/github.com/diadata-org/api-golang/blockchain-scrapers/cmd/xlm
+
+RUN go install
+
+FROM gcr.io/distroless/base
+
+COPY --from=build /go/bin/xlm /bin/xlm
+
+CMD ["xlm"]

--- a/blockchain-scrapers/cmd/xlm/xlm.go
+++ b/blockchain-scrapers/cmd/xlm/xlm.go
@@ -44,20 +44,20 @@ func main() {
 			responseData, err := ioutil.ReadAll(response.Body)
 			if err != nil {
 				log.Println("Failed to retrieve ada supply: ", err)
-			}
-			var supplyObject Supply
-			json.Unmarshal(responseData, &supplyObject)
-			result, cerr := strconv.ParseFloat(supplyObject.Distributed, 64)
-			if cerr != nil {
-				fmt.Println("There was an integer conversion error:", err)
-			}
-			fmt.Printf("Symbol: %s ; circulatingSupply: %f\n", symbol, result)
-			if prevResult != result {
-				client.SendSupply(&dia.Supply{
-					Symbol:            symbol,
-					CirculatingSupply: result,
-				})
-				prevResult = result
+			} else {
+				var supplyObject Supply
+				json.Unmarshal(responseData, &supplyObject)
+				result, cerr := strconv.ParseFloat(supplyObject.Available, 64)
+				if cerr == nil {
+					fmt.Printf("Symbol: %s ; circulatingSupply: %f\n", symbol, result)
+					if prevResult != result {
+						client.SendSupply(&dia.Supply{
+							Symbol:            symbol,
+							CirculatingSupply: result,
+						})
+						prevResult = result
+					}
+				}
 			}
 		} else {
 			log.Println("Err communicating with node:", err)

--- a/blockchain-scrapers/cmd/xlm/xlm.go
+++ b/blockchain-scrapers/cmd/xlm/xlm.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+)
+
+type Supply struct {
+	Updatad     string  `json:"updatedAt"`
+	Total       float64 `json:"totalCoins"`
+	Available   float64 `json:"availableCoins"`
+	Distributed float64 `json:"distributedCoins"`
+	Programs    struct {
+		Direct      float64 `json:"directProgram"`
+		Bitcoin     float64 `json:"bitcoinProgram"`
+		Partnership float64 `json:"partnershipProgram"`
+		Build       int     `json:"buildChallenge"`
+	} `json:"programs"`
+}
+
+const endpoint = "https://dashboard.stellar.org/api/lumens"
+const symbol = "XLM"
+
+func main() {
+	// config := dia.GetConfigApi()
+	// if config == nil {
+	// 	panic("Couldnt load config")
+	// }
+	// client := dia.NewClient(config)
+	// if client == nil {
+	// 	panic("Couldnt load client")
+	// }
+	// prevResult := 0.0
+	for {
+		response, err := http.Get(endpoint)
+		if err == nil {
+			responseData, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				log.Println("Failed to retrieve ada supply: ", err)
+			}
+			var supplyObject Supply
+			json.Unmarshal(responseData, &supplyObject)
+			result := supplyObject.Distributed
+			fmt.Printf("Symbol: %s ; circulatingSupply: %f\n", symbol, result)
+			// if prevResult != result {
+			// 	client.SendSupply(&dia.Supply{
+			// 		Symbol:            symbol,
+			// 		CirculatingSupply: result,
+			// 	})
+			// 	prevResult = result
+			// }
+		} else {
+			log.Println("Err communicating with node:", err)
+		}
+		time.Sleep(time.Second * 10)
+	}
+
+}

--- a/blockchain-scrapers/cmd/xlm/xlm.go
+++ b/blockchain-scrapers/cmd/xlm/xlm.go
@@ -6,19 +6,22 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strconv"
 	"time"
+
+	"github.com/diadata-org/api-golang/dia"
 )
 
 type Supply struct {
-	Updatad     string  `json:"updatedAt"`
-	Total       float64 `json:"totalCoins"`
-	Available   float64 `json:"availableCoins"`
-	Distributed float64 `json:"distributedCoins"`
+	Updatad     string `json:"updatedAt"`
+	Total       string `json:"totalCoins"`
+	Available   string `json:"availableCoins"`
+	Distributed string `json:"distributedCoins"`
 	Programs    struct {
-		Direct      float64 `json:"directProgram"`
-		Bitcoin     float64 `json:"bitcoinProgram"`
-		Partnership float64 `json:"partnershipProgram"`
-		Build       int     `json:"buildChallenge"`
+		Direct      string `json:"directProgram"`
+		Bitcoin     string `json:"bitcoinProgram"`
+		Partnership string `json:"partnershipProgram"`
+		Build       string `json:"buildChallenge"`
 	} `json:"programs"`
 }
 
@@ -26,15 +29,15 @@ const endpoint = "https://dashboard.stellar.org/api/lumens"
 const symbol = "XLM"
 
 func main() {
-	// config := dia.GetConfigApi()
-	// if config == nil {
-	// 	panic("Couldnt load config")
-	// }
-	// client := dia.NewClient(config)
-	// if client == nil {
-	// 	panic("Couldnt load client")
-	// }
-	// prevResult := 0.0
+	config := dia.GetConfigApi()
+	if config == nil {
+		panic("Couldnt load config")
+	}
+	client := dia.NewClient(config)
+	if client == nil {
+		panic("Couldnt load client")
+	}
+	prevResult := 0.0
 	for {
 		response, err := http.Get(endpoint)
 		if err == nil {
@@ -44,19 +47,21 @@ func main() {
 			}
 			var supplyObject Supply
 			json.Unmarshal(responseData, &supplyObject)
-			result := supplyObject.Distributed
+			result, cerr := strconv.ParseFloat(supplyObject.Distributed, 64)
+			if cerr != nil {
+				fmt.Println("There was an integer conversion error:", err)
+			}
 			fmt.Printf("Symbol: %s ; circulatingSupply: %f\n", symbol, result)
-			// if prevResult != result {
-			// 	client.SendSupply(&dia.Supply{
-			// 		Symbol:            symbol,
-			// 		CirculatingSupply: result,
-			// 	})
-			// 	prevResult = result
-			// }
+			if prevResult != result {
+				client.SendSupply(&dia.Supply{
+					Symbol:            symbol,
+					CirculatingSupply: result,
+				})
+				prevResult = result
+			}
 		} else {
 			log.Println("Err communicating with node:", err)
 		}
 		time.Sleep(time.Second * 10)
 	}
-
 }

--- a/blockchain-scrapers/docker-compose.yml
+++ b/blockchain-scrapers/docker-compose.yml
@@ -139,6 +139,18 @@ services:
         max-size: "50m"
     secrets:
       - api_diadata
+  xlm:
+    build:
+      context: ../../../..
+      dockerfile: github.com/diadata-org/api-golang/blockchain-scrapers/Dockerfile-xlm
+    image: ${DOCKER_HUB_LOGIN}/blockchain-scrapers_xlm
+    networks:
+      - scrapers-network
+    logging:
+      options:
+        max-size: "50m"
+    secrets:
+      - api_diadata
 volumes:
   bitcoin:
 


### PR DESCRIPTION
I used the public api of https://dashboard.stellar.org/ to retrieve lumens distributed which is the circulating supply term for stellar. This api is not available through the standard node api that horizon serves: https://www.stellar.org/developers/horizon/reference/index.html which is what the official docker image runs. Or I would have used the docker image.