### PR TITLE
added go module for neo and dockerfile,updated docker-compose

### DIFF
--- a/blockchain-scrapers/Dockerfile-neo
+++ b/blockchain-scrapers/Dockerfile-neo
@@ -1,0 +1,15 @@
+FROM golang:latest as build
+
+WORKDIR $GOPATH/src/
+
+COPY . .
+
+WORKDIR $GOPATH/src/github.com/diadata-org/api-golang/blockchain-scrapers/cmd/neo
+
+RUN go install
+
+FROM gcr.io/distroless/base
+
+COPY --from=build /go/bin/neo /bin/neo
+
+CMD ["neo"]

--- a/blockchain-scrapers/cmd/neo/neo.go
+++ b/blockchain-scrapers/cmd/neo/neo.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/diadata-org/api-golang/dia"
+)
+
+//to get the NEO client node, run `docker run -it -d -p 10332:10332 ubuntu-neo-cli`
+//ubuntu-neo-cli can be found at petertakhar/ubuntu-neo-cli
+
+var (
+	//address of your local node
+	clientNode     = "0.0.0.0:10332"
+	holdingAddress = "AQVh2pG732YvtNaxEGkQUei3YA4cvo7d2i"
+)
+
+//total cap of NEO coins to be released
+const MAXSUPPLY = 100000000
+const symbol = "NEO"
+
+//set a timer on the length of http connections
+var netClient = &http.Client{
+	Timeout: time.Second * 15,
+}
+
+//Account is a representation of the account's assets and their values
+type Account struct {
+	Result struct {
+		Balances []struct {
+			Asset string `json:"asset"`
+			Value string `json:"value"`
+		} `json:"balances"`
+	} `json:"result"`
+}
+
+//calculates the circulating supply of NEO
+func main() {
+
+	//list of static rpc nodes found at https://github.com/"CityOfZion/neo-api-js/wiki
+	//used to verify if local blockchain is fully synchronized with the main net
+	var staticNodes [4]string
+	staticNodes[0] = "seed2.neo.org:10332"
+	staticNodes[1] = "seed3.neo.org:10332"
+	staticNodes[2] = "seed4.neo.org:10332"
+	staticNodes[3] = "seed5.neo.org:10332"
+
+	var node string
+
+	//sets the node to pull data depending on synchronization status of local node
+	if isBlockchainSynchronized(staticNodes[0]) {
+		node = clientNode
+	} else {
+		fmt.Println("Blockchain is not synchronized yet. " +
+			"Pulling data from another fully synchronized node")
+		node = staticNodes[0]
+	}
+
+	url := fmt.Sprintf("http://%s?jsonrpc=2.0&method=getaccountstate&params=[\"%s\"]&id=1",
+		node, holdingAddress)
+
+	resp, err := netClient.Get(url)
+	if err != nil {
+		log.Fatalf("Failed to connect to the local node: %v", err)
+	}
+
+	accountData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Failed to retrive json from node: %v", err)
+	}
+	resp.Body.Close()
+
+	var account Account
+	err = json.Unmarshal(accountData, &account)
+	if err != nil {
+		log.Fatalf("Failed to unmarshal Account data: %v", err)
+	}
+
+	/*the index is calculated using account.Result.Balances-1 because if there are
+	  multiple assets, then the balance of NEO coins are always the last index
+	*/
+	accountBalanceNEO, err := strconv.ParseFloat(
+		account.Result.Balances[len(account.Result.Balances)-1].Value, 64)
+	if err != nil {
+		log.Fatalf("Failed to convert account balancee to float: %v ", err)
+	}
+
+	circSupplyAmount := MAXSUPPLY - accountBalanceNEO
+	fmt.Printf("Circrulating Supply Amount: %f\n", circSupplyAmount)
+
+	config := dia.GetConfigApi()
+	if config == nil {
+		panic("Couldnt load config")
+	}
+	client := dia.NewClient(config)
+	if client == nil {
+		panic("Couldnt load client")
+	}
+
+	client.SendSupply(&dia.Supply{
+		Symbol:            symbol,
+		CirculatingSupply: circSupplyAmount,
+	})
+
+}
+
+/*determines if local node has up-to-date blockchain by comparing block heights
+with a fully synchonized node
+*/
+func isBlockchainSynchronized(otherNode string) bool {
+
+	otherNodeHeight := getClientBlockHeight(otherNode)
+	myHeight := getClientBlockHeight(clientNode)
+	fmt.Printf("Current node block height: %f ; Other node block height: %f\n",
+		myHeight, otherNodeHeight)
+	return myHeight >= otherNodeHeight
+}
+
+//pulls the block height from a NEO node
+func getClientBlockHeight(ip string) float64 {
+	query := "?jsonrpc=2.0&method=getblockcount&params=[]&id=1"
+
+	resp, err := netClient.Get(fmt.Sprintf("http://%s%s", ip, query))
+	if err != nil {
+		log.Fatalf("Failed to connect to node: %v", err)
+	}
+
+	blockHeightContent, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Failed to retrive json from node: %v", err)
+	}
+	resp.Body.Close()
+
+	blockHeightData := make(map[string]interface{})
+	err = json.Unmarshal(blockHeightContent, &blockHeightData)
+	if err != nil {
+		log.Fatalf("Failed to unmarshal block height data: %v", err)
+	}
+
+	height, ok := blockHeightData["result"].(float64)
+	if !ok {
+		log.Fatalf("JSON value must be float64")
+	}
+
+	return height
+}

--- a/blockchain-scrapers/docker-compose.yml
+++ b/blockchain-scrapers/docker-compose.yml
@@ -78,6 +78,21 @@ services:
       restart_policy:
         delay: 2s
         window: 20s
+  neo:
+    image:
+      petertakhar/ubuntu-neo-cli
+    ports:
+      - "10332"
+    logging:
+      options:
+        max-size: "50m"
+    networks:
+      - scrapers-network
+    deploy:
+      mode: global
+      restart_policy:
+        delay: 2s
+        window: 20s
   btc:
     build:
       context: ../../../..
@@ -144,6 +159,18 @@ services:
       context: ../../../..
       dockerfile: github.com/diadata-org/api-golang/blockchain-scrapers/Dockerfile-xrp
     image: ${DOCKER_HUB_LOGIN}/blockchain-scrapers_xrp
+    networks:
+      - scrapers-network
+    logging:
+      options:
+        max-size: "50m"
+    secrets:
+      - api_diadata    
+  neo:
+    build:
+      context: ../../../..
+      dockerfile: github.com/diadata-org/api-golang/blockchain-scrapers/Dockerfile-neo
+    image: ${DOCKER_HUB_LOGIN}/blockchain-scrapers_neo
     networks:
       - scrapers-network
     logging:


### PR DESCRIPTION
The go modules return the correct circulating supply with data scrapped from the NEO blockchain while I created containers with this command: docker run -it -d -p 10332:10332 ubuntu-neo-cli . 

The client takes a very long time synchronising with the mainnet initially. It took over 3-4 days for the sync to be completed. I decided to include a function that checks whether the sync is completed and if its not, then a static node will used instead to query for an account's balance. It is recommended to download an offline version of the blockchain data to speed up syncing, but I figured having to download 3.4gb file would be very slow. Here is the relevant information in the official docs: http://docs.neo.org/en-us/network/syncblocks.html
I also wasn't able to find any command that enabled pruning on the blockchain. It doesn't look like it has been implemented yet.

I used my own docker image, which can be found here: https://github.com/Peter-Takhar/dockerfile-neo-cli . It just simply sets up a node which can be interacted with through JSON-RPC API.
If there's anything I can fix or improve upon, please let me know.  