### PR TITLE
add Scraper for Huobi Exchange

### DIFF
--- a/dia/Config.go
+++ b/dia/Config.go
@@ -15,6 +15,7 @@ const (
 	HitBTCExchange   = "HitBTC"
 	SimexExchange    = "Simex"
 	OKExExchange     = "OKEx"
+	HuobiExchange    = "Huobi"
 	UnknownExchange  = "Unknown"
 )
 
@@ -26,6 +27,7 @@ func Exchanges() []string {
 		CoinBaseExchange,
 		HitBTCExchange,
 		SimexExchange,
+		HuobiExchange,
 		OKExExchange}
 }
 

--- a/exchange-scrapers/config/exchange-scrapers.json
+++ b/exchange-scrapers/config/exchange-scrapers.json
@@ -404,6 +404,156 @@
       "Symbol": "NEO",
       "ForeignName": "NEO_USDT",
       "Exchange": "OKEx"
+    },
+    {
+      "Symbol": "ETH",
+      "ForeignName": "ETHBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "ETH",
+      "ForeignName": "ETHUSDT",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "BTC",
+      "ForeignName": "BTCUSDT",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "BCH",
+      "ForeignName": "BCHBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "LTC",
+      "ForeignName": "LTCBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName": "ETCBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "EOS",
+      "ForeignName": "EOSBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "ADA",
+      "ForeignName": "ADABTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "XRP",
+      "ForeignName": "XRPBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "IOTA",
+      "ForeignName": "IOTABTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "DASH",
+      "ForeignName": "DASHBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "XMR",
+      "ForeignName": "XMRBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "EOS",
+      "ForeignName": "EOSETH",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "IOTA",
+      "ForeignName": "IOTAETH",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "OMG",
+      "ForeignName": "OMGETH",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "OMG",
+      "ForeignName": "OMGBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "XMR",
+      "ForeignName": "XMRETH",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "ADA",
+      "ForeignName": "ADAETH",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "STEEM",
+      "ForeignName": "STEEMETH",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "ZEC",
+      "ForeignName": "ZECBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "STEEM",
+      "ForeignName": "STEEMBTC",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "BCH",
+      "ForeignName": "BCHUSDT",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName": "ETCUSDT",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "LTC",
+      "ForeignName": "LTCUSDT",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "EOS",
+      "ForeignName": "EOSUSDT",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "ADA",
+      "ForeignName": "ADAUSDT",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "XRP",
+      "ForeignName": "XRPUSDT",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "IOTA",
+      "ForeignName": "IOTAUSDT",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "DASH",
+      "ForeignName": "DASHUSDT",
+      "Exchange": "Huobi"
+    },
+    {
+      "Symbol": "OMG",
+      "ForeignName": "OMGUSDT",
+      "Exchange": "Huobi"
     }
   ]
 }

--- a/exchange-scrapers/scrapers/APIScraper.go
+++ b/exchange-scrapers/scrapers/APIScraper.go
@@ -50,6 +50,8 @@ func NewAPIScraper(exchange string, key string, secret string) APIScraper {
 		return NewSimexScraper()
 	case dia.OKExExchange:
 		return NewOKExScraper()
+	case dia.HuobiExchange:
+		return NewHuobiScraper()
 	default:
 		return nil
 	}

--- a/exchange-scrapers/scrapers/HuobiScraper.go
+++ b/exchange-scrapers/scrapers/HuobiScraper.go
@@ -1,0 +1,239 @@
+package scrapers
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/diadata-org/api-golang/dia"
+	ws "github.com/gorilla/websocket"
+)
+
+var _HuobiSocketurl string = "wss://api.huobi.pro/ws"
+
+type EventType struct {
+	Sub  string `json:"sub,omitempty"`
+	Id   string `json:"id,omitempty"`
+	Pong int    `json:"pong,omitempty"`
+}
+
+type ResponseType struct {
+	Id     int64       `json:"id,omitempty"`
+	Status string      `json:"status,omitempty"`
+	Subbed string      `json:"subbed,omitempty"`
+	Ts     int64       `json:"ts,omitempty"`
+	Ping   int         `json:"ping,omitempty"`
+	Ch     string      `json:"ch,omitempty"`
+	Tick   interface{} `json:"tick,omitempty"`
+}
+
+type HuobiScraper struct {
+	wsClient *ws.Conn
+	// signaling channels for session initialization and finishing
+	//initDone     chan nothing
+	shutdown     chan nothing
+	shutdownDone chan nothing
+	// error handling; to read error or closed, first acquire read lock
+	// only cleanup method should hold write lock
+	errorLock sync.RWMutex
+	error     error
+	closed    bool
+	// used to keep track of trading pairs that we subscribed to
+	pairScrapers map[string]*HuobiPairScraper
+}
+
+// NewHuobiScraper returns a new HuobiScraper for the given pair
+func NewHuobiScraper() *HuobiScraper {
+
+	s := &HuobiScraper{
+		shutdown:     make(chan nothing),
+		shutdownDone: make(chan nothing),
+		pairScrapers: make(map[string]*HuobiPairScraper),
+		error:        nil,
+	}
+
+	var wsDialer ws.Dialer
+	SwConn, _, err := wsDialer.Dial(_HuobiSocketurl, nil)
+
+	if err != nil {
+		println(err.Error())
+	}
+
+	s.wsClient = SwConn
+	go s.mainLoop()
+	return s
+}
+
+// runs in a goroutine until s is closed
+func (s *HuobiScraper) mainLoop() {
+
+	for true {
+
+		message := &ResponseType{}
+		_, test_read, err := s.wsClient.NextReader()
+
+		if err != nil {
+			fmt.Println(err.Error())
+		} else {
+
+			//It has to gzip response data
+			reader, _ := gzip.NewReader(test_read)
+			jsonBase := json.NewDecoder(reader)
+			jsonBase.Decode(message)
+
+			// If msg is ping type, it needs to resend a pong msg to ws.
+			// for avoid to disconnect it
+			if message.Ping > 0 {
+
+				a := &EventType{
+					Pong: message.Ping,
+				}
+
+				if err := s.wsClient.WriteJSON(a); err != nil {
+					fmt.Println(err.Error())
+				}
+			} else {
+
+				if message.Status == "" {
+
+					var splitString = strings.Split(message.Ch, ".")
+					var forName = strings.ToUpper(splitString[1])
+					ps, ok := s.pairScrapers[forName]
+
+					if ok {
+
+						md := message.Tick.(map[string]interface{})
+						md_data := md["data"].([]interface{})
+
+						for _, value := range md_data {
+
+							md_element := value.(map[string]interface{})
+							f64Price := md_element["price"].(float64)
+							f64Volume := md_element["amount"].(float64)
+							timeStamp := time.Now().UTC()
+
+							if md_element["direction"] == "sell" {
+								f64Volume = -f64Volume
+							}
+
+							// element id is more than int64/uint64 in size
+							// leave the id in float64 format
+							t := &dia.Trade{
+								Symbol:         ps.pair.Symbol,
+								Pair:           forName,
+								Price:          f64Price,
+								Volume:         f64Volume,
+								Time:           timeStamp,
+								ForeignTradeID: strconv.FormatFloat(md_element["id"].(float64), 'E', -1, 64),
+								Source:         dia.HuobiExchange,
+							}
+							ps.chanTrades <- t
+						}
+					} else {
+						log.Printf("Unknown Pair %v", forName)
+					}
+				}
+			}
+		}
+	}
+}
+
+func (s *HuobiScraper) cleanup(err error) {
+	s.errorLock.Lock()
+	defer s.errorLock.Unlock()
+
+	if err != nil {
+		s.error = err
+	}
+	s.closed = true
+
+	close(s.shutdownDone)
+}
+
+// Close closes any existing API connections, as well as channels of
+// PairScrapers from calls to ScrapePair
+func (s *HuobiScraper) Close() error {
+
+	if s.closed {
+		return errors.New("HuobiScraper: Already closed")
+	}
+
+	close(s.shutdown)
+	<-s.shutdownDone
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+	return s.error
+}
+
+// ScrapePair returns a PairScraper that can be used to get trades for a single pair from
+// this APIScraper
+func (s *HuobiScraper) ScrapePair(pair dia.Pair) (PairScraper, error) {
+
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+
+	if s.error != nil {
+		return nil, s.error
+	}
+
+	if s.closed {
+		return nil, errors.New("HuobiScraper: Call ScrapePair on closed scraper")
+	}
+
+	ps := &HuobiPairScraper{
+		parent:     s,
+		pair:       pair,
+		chanTrades: make(chan *dia.Trade),
+	}
+
+	s.pairScrapers[pair.ForeignName] = ps
+
+	a := &EventType{
+		Sub: "market." + strings.ToLower(pair.ForeignName) + ".trade.detail",
+		Id:  "id1",
+	}
+
+	if err := s.wsClient.WriteJSON(a); err != nil {
+		fmt.Println(err.Error())
+	}
+
+	return ps, nil
+}
+
+// HuobiPairScraper implements PairScraper for Huobi exchange
+type HuobiPairScraper struct {
+	parent     *HuobiScraper
+	pair       dia.Pair
+	chanTrades chan *dia.Trade
+	closed     bool
+}
+
+// Close stops listening for trades of the pair associated with s
+func (ps *HuobiPairScraper) Close() error {
+	return nil
+}
+
+// Channel returns a channel that can be used to receive trades
+func (ps *HuobiPairScraper) Channel() chan *dia.Trade {
+	return ps.chanTrades
+}
+
+// Error returns an error when the channel Channel() is closed
+// and nil otherwise
+func (ps *HuobiPairScraper) Error() error {
+	s := ps.parent
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+	return s.error
+}
+
+// Pair returns the pair this scraper is subscribed to
+func (ps *HuobiPairScraper) Pair() dia.Pair {
+	return ps.pair
+}


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->
- This PR add a trade history scraper for Huobi Exchange.
- 30 crypto pairs added to `exchange-scrapers.json`
- I have used UTC timestamp instead of `ts` parameter retrieved from response because it is not a unix timestamp.The difference in time could be at most 2/3 seconds.
- The `id` parameter for each trade is a value more than `int64/uint64` in size, it causes an overflow. I have left the id in `float64` (example:1.884369602511794e+21)
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Changes don't break existing behavior

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
Core Scraper

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
I tested the code in MacOS environment, using go version 1.10.3

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: #3 
