### PR TITLE
add scraper for GateIO Exchange

### DIFF
--- a/dia/Config.go
+++ b/dia/Config.go
@@ -17,6 +17,7 @@ const (
 	OKExExchange     = "OKEx"
 	HuobiExchange    = "Huobi"
 	LBankExchange    = "LBank"
+	GateIOExchange   = "GateIO"
 	UnknownExchange  = "Unknown"
 )
 
@@ -30,6 +31,7 @@ func Exchanges() []string {
 		SimexExchange,
 		HuobiExchange,
 		LBankExchange,
+		GateIOExchange,
 		OKExExchange}
 }
 

--- a/exchange-scrapers/config/exchange-scrapers.json
+++ b/exchange-scrapers/config/exchange-scrapers.json
@@ -654,6 +654,131 @@
       "Symbol": "VET",
       "ForeignName": "VET_USDT",
       "Exchange": "LBank"
+    },
+    {
+      "Symbol": "ETH",
+      "ForeignName": "ETH_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "BTC",
+      "ForeignName": "BTC_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "BCH",
+      "ForeignName": "BCH_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "LTC",
+      "ForeignName": "LTC_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "DOGE",
+      "ForeignName": "DOGE_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "EOS",
+      "ForeignName": "EOS_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName": "ETC_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "XRP",
+      "ForeignName": "XRP_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "ZEC",
+      "ForeignName": "ZEC_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "NEO",
+      "ForeignName": "NEO_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "XMR",
+      "ForeignName": "XMR_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "IOTA",
+      "ForeignName": "IOTA_USDT",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "ETH",
+      "ForeignName": "ETH_BTC",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "DOGE",
+      "ForeignName": "DOGE_BTC",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "EOS",
+      "ForeignName": "EOS_BTC",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "BCH",
+      "ForeignName": "BCH_BTC",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "DASH",
+      "ForeignName": "DASH_BTC",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName": "ETC_BTC",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "OMG",
+      "ForeignName": "OMG_BTC",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "ADA",
+      "ForeignName": "ADA_BTC",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "EOS",
+      "ForeignName": "EOS_ETH",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "BAT",
+      "ForeignName": "BAT_ETH",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName": "ETC_ETH",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "OMG",
+      "ForeignName": "OMG_ETH",
+      "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "VET",
+      "ForeignName": "VET_ETH",
+      "Exchange": "GateIO"
     }
   ]
 }

--- a/exchange-scrapers/scrapers/APIScraper.go
+++ b/exchange-scrapers/scrapers/APIScraper.go
@@ -54,6 +54,8 @@ func NewAPIScraper(exchange string, key string, secret string) APIScraper {
 		return NewHuobiScraper()
 	case dia.LBankExchange:
 		return NewLBankScraper()
+	case dia.GateIOExchange:
+		return NewGateIOScraper()
 	default:
 		return nil
 	}

--- a/exchange-scrapers/scrapers/GateIOScraper.go
+++ b/exchange-scrapers/scrapers/GateIOScraper.go
@@ -1,0 +1,235 @@
+package scrapers
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/diadata-org/api-golang/dia"
+	ws "github.com/gorilla/websocket"
+)
+
+var _GateIOsocketurl string = "wss://ws.gate.io/v3"
+
+type SubscribeGate struct {
+	Id     int      `json:"id"`
+	Method string   `json:"method"`
+	Params []string `json:"params"`
+}
+
+type ResponseGate struct {
+	Method string        `json:"method,omitempty"`
+	Params []interface{} `json:"params,omitempty"`
+	Id     interface{}   `json:"id,omitempty"`
+}
+
+type GateIOScraper struct {
+	wsClient *ws.Conn
+	// signaling channels for session initialization and finishing
+	//initDone     chan nothing
+	shutdown     chan nothing
+	shutdownDone chan nothing
+	// error handling; to read error or closed, first acquire read lock
+	// only cleanup method should hold write lock
+	errorLock sync.RWMutex
+	error     error
+	closed    bool
+	// used to keep track of trading pairs that we subscribed to
+	pairScrapers map[string]*GateIOPairScraper
+}
+
+// NewGateIOScraper returns a new GateIOScraper for the given pair
+func NewGateIOScraper() *GateIOScraper {
+
+	s := &GateIOScraper{
+		shutdown:     make(chan nothing),
+		shutdownDone: make(chan nothing),
+		pairScrapers: make(map[string]*GateIOPairScraper),
+		error:        nil,
+	}
+
+	var wsDialer ws.Dialer
+	SwConn, _, err := wsDialer.Dial(_GateIOsocketurl, nil)
+
+	if err != nil {
+		println(err.Error())
+	}
+
+	s.wsClient = SwConn
+	go s.mainLoop()
+	return s
+}
+
+// runs in a goroutine until s is closed
+func (s *GateIOScraper) mainLoop() {
+
+	// wait for all pairs have added into s.PairScrapers
+	time.Sleep(4 * time.Second)
+	allPairs := make([]string, len(s.pairScrapers))
+	var index = 0
+	for key, _ := range s.pairScrapers {
+		allPairs[index] = key
+		index += 1
+	}
+
+	// Only one subscribe for all pairs
+	a := &SubscribeGate{
+		Id:     12312,
+		Method: "trades.subscribe",
+		Params: allPairs,
+	}
+
+	if err := s.wsClient.WriteJSON(a); err != nil {
+		fmt.Println(err.Error())
+	}
+
+	for true {
+
+		message := &ResponseGate{}
+		if err := s.wsClient.ReadJSON(&message); err != nil {
+			println(err.Error())
+			break
+		}
+		var pairRetrieved string
+		for key, v := range message.Params {
+
+			// key 0 -> pair
+			// key 1 -> datas
+			if key == 0 {
+
+				pairRetrieved = v.(string)
+
+			}
+			if key == 1 {
+
+				ps, ok := s.pairScrapers[pairRetrieved]
+				if ok {
+
+					md := v.([]interface{})
+					for _, v := range md {
+
+						md_inner := v.(map[string]interface{})
+						f64Price_string := md_inner["price"].(string)
+						f64Price, err := strconv.ParseFloat(f64Price_string, 64)
+
+						if err == nil {
+
+							f64Volume_string := md_inner["amount"].(string)
+							f64Volume, err := strconv.ParseFloat(f64Volume_string, 64)
+
+							if err == nil {
+								if md_inner["type"] == "sell" {
+									f64Volume = -f64Volume
+								}
+								timestamp_temp := int64(md_inner["time"].(float64))
+								timestamp := time.Unix(timestamp_temp, 0).UTC()
+								t := &dia.Trade{
+									Symbol:         ps.pair.Symbol,
+									Pair:           pairRetrieved,
+									Price:          f64Price,
+									Volume:         f64Volume,
+									Time:           timestamp,
+									ForeignTradeID: strconv.FormatInt(int64(md_inner["id"].(float64)), 16),
+									Source:         dia.GateIOExchange,
+								}
+								ps.chanTrades <- t
+							} else {
+								log.Printf("error parsing volume %v", md_inner["amount"].(string))
+							}
+						} else {
+							log.Printf("error parsing price %v", md_inner["price"].(string))
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func (s *GateIOScraper) cleanup(err error) {
+	s.errorLock.Lock()
+	defer s.errorLock.Unlock()
+
+	if err != nil {
+		s.error = err
+	}
+	s.closed = true
+
+	close(s.shutdownDone)
+}
+
+// Close closes any existing API connections, as well as channels of
+// PairScrapers from calls to ScrapePair
+func (s *GateIOScraper) Close() error {
+
+	if s.closed {
+		return errors.New("GateIOScraper: Already closed")
+	}
+
+	close(s.shutdown)
+	<-s.shutdownDone
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+	return s.error
+}
+
+// ScrapePair returns a PairScraper that can be used to get trades for a single pair from
+// this APIScraper
+func (s *GateIOScraper) ScrapePair(pair dia.Pair) (PairScraper, error) {
+
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+
+	if s.error != nil {
+		return nil, s.error
+	}
+
+	if s.closed {
+		return nil, errors.New("GateIOScraper: Call ScrapePair on closed scraper")
+	}
+
+	ps := &GateIOPairScraper{
+		parent:     s,
+		pair:       pair,
+		chanTrades: make(chan *dia.Trade),
+	}
+
+	s.pairScrapers[pair.ForeignName] = ps
+
+	return ps, nil
+}
+
+// GateIOPairScraper implements PairScraper for GateIO
+type GateIOPairScraper struct {
+	parent     *GateIOScraper
+	pair       dia.Pair
+	chanTrades chan *dia.Trade
+	closed     bool
+}
+
+// Close stops listening for trades of the pair associated with s
+func (ps *GateIOPairScraper) Close() error {
+	return nil
+}
+
+// Channel returns a channel that can be used to receive trades
+func (ps *GateIOPairScraper) Channel() chan *dia.Trade {
+	return ps.chanTrades
+}
+
+// Error returns an error when the channel Channel() is closed
+// and nil otherwise
+func (ps *GateIOPairScraper) Error() error {
+	s := ps.parent
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+	return s.error
+}
+
+// Pair returns the pair this scraper is subscribed to
+func (ps *GateIOPairScraper) Pair() dia.Pair {
+	return ps.pair
+}


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->
- This PR adds a scraper for GateIO Exchange.
- Add 25 pairs.
- The logic is little different, It needs only one subscribtion to `ws`,  it pass all pairs as parameters.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Changes don't break existing behavior

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
Exchange Scraper core

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
- I tested the code in Mac OS environment, using go1.10.3

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: #45 