### PR TITLE
Add ZB exchange scraper

### DIFF
--- a/dia/Config.go
+++ b/dia/Config.go
@@ -18,6 +18,7 @@ const (
 	HuobiExchange    = "Huobi"
 	LBankExchange    = "LBank"
 	GateIOExchange   = "GateIO"
+	ZBExchange       = "ZB"
 	UnknownExchange  = "Unknown"
 )
 
@@ -32,7 +33,9 @@ func Exchanges() []string {
 		HuobiExchange,
 		LBankExchange,
 		GateIOExchange,
-		OKExExchange}
+		OKExExchange,
+		ZBExchange,
+	}
 }
 
 type ConfigApi struct {

--- a/exchange-scrapers/config/exchange-scrapers.json
+++ b/exchange-scrapers/config/exchange-scrapers.json
@@ -779,6 +779,1036 @@
       "Symbol": "VET",
       "ForeignName": "VET_ETH",
       "Exchange": "GateIO"
+    },
+    {
+      "Symbol": "1ST",
+      "ForeignName": "1stbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "1ST",
+      "ForeignName": "1stqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "1ST",
+      "ForeignName": "1stusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "AAA",
+      "ForeignName": "aaaqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ADA",
+      "ForeignName": "adabtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ADA",
+      "ForeignName": "adaqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ADA",
+      "ForeignName": "adausdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "AE",
+      "ForeignName": "aebtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "AE",
+      "ForeignName": "aeqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "AE",
+      "ForeignName": "aeusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BAT",
+      "ForeignName": "batbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BAT",
+      "ForeignName": "batqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BAT",
+      "ForeignName": "batusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCC",
+      "ForeignName": "bccbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCC",
+      "ForeignName": "bccqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCC",
+      "ForeignName": "bccusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCC",
+      "ForeignName": "bcczb",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCD",
+      "ForeignName": "bcdbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCD",
+      "ForeignName": "bcdqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCD",
+      "ForeignName": "bcdusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCW",
+      "ForeignName": "bcwbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCW",
+      "ForeignName": "bcwqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCW",
+      "ForeignName": "bcwusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCX",
+      "ForeignName": "bcxbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCX",
+      "ForeignName": "bcxqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BCX",
+      "ForeignName": "bcxusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BDS",
+      "ForeignName": "bdsbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BDS",
+      "ForeignName": "bdsqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BITCNY",
+      "ForeignName": "bitcnyqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BITE",
+      "ForeignName": "bitebtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTC",
+      "ForeignName": "btcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTC",
+      "ForeignName": "btcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTH",
+      "ForeignName": "bthbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTH",
+      "ForeignName": "bthqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTH",
+      "ForeignName": "bthusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTM",
+      "ForeignName": "btmbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTM",
+      "ForeignName": "btmqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTM",
+      "ForeignName": "btmusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTN",
+      "ForeignName": "btnbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTN",
+      "ForeignName": "btnqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTN",
+      "ForeignName": "btnusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTP",
+      "ForeignName": "btpbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTP",
+      "ForeignName": "btpqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTP",
+      "ForeignName": "btpusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTS",
+      "ForeignName": "btsbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTS",
+      "ForeignName": "btsqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTS",
+      "ForeignName": "btsusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "BTS",
+      "ForeignName": "btszb",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "CDC",
+      "ForeignName": "cdcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "CDC",
+      "ForeignName": "cdcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "CDC",
+      "ForeignName": "cdcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "CHAT",
+      "ForeignName": "chatbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "CHAT",
+      "ForeignName": "chatqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "CHAT",
+      "ForeignName": "chatusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "DASH",
+      "ForeignName": "dashbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "DASH",
+      "ForeignName": "dashqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "DASH",
+      "ForeignName": "dashusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "DASH",
+      "ForeignName": "dashzb",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "DDM",
+      "ForeignName": "ddmbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "DDM",
+      "ForeignName": "ddmqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "DDM",
+      "ForeignName": "ddmusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "DOGE",
+      "ForeignName": "dogebtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "DOGE",
+      "ForeignName": "dogeqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "DOGE",
+      "ForeignName": "dogeusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EDO",
+      "ForeignName": "edobtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EDO",
+      "ForeignName": "edoqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EDO",
+      "ForeignName": "edousdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ENT",
+      "ForeignName": "entbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ENT",
+      "ForeignName": "entqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ENT",
+      "ForeignName": "entusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EOS",
+      "ForeignName": "eosbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EOS",
+      "ForeignName": "eosqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EOS",
+      "ForeignName": "eosusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EOS",
+      "ForeignName": "eoszb",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EOSDAC",
+      "ForeignName": "eosdacbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EOSDAC",
+      "ForeignName": "eosdacqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EOSDAC",
+      "ForeignName": "eosdacusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EPC",
+      "ForeignName": "epcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "EPC",
+      "ForeignName": "epcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName": "etcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName": "etcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName": "etcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName": "etczb",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ETH",
+      "ForeignName": "ethbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ETH",
+      "ForeignName": "ethqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ETH",
+      "ForeignName": "ethusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ETH",
+      "ForeignName": "ethzb",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "FUN",
+      "ForeignName": "funbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "FUN",
+      "ForeignName": "funqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "FUN",
+      "ForeignName": "funusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "GNT",
+      "ForeignName": "gntbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "GNT",
+      "ForeignName": "gntqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "GNT",
+      "ForeignName": "gntusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "GRAM",
+      "ForeignName": "grambtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "GRAM",
+      "ForeignName": "gramqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "GRAM",
+      "ForeignName": "gramusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HLC",
+      "ForeignName": "hlcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HLC",
+      "ForeignName": "hlcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HLC",
+      "ForeignName": "hlcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HOTC",
+      "ForeignName": "hotcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HOTC",
+      "ForeignName": "hotcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HOTC",
+      "ForeignName": "hotcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HPY",
+      "ForeignName": "hpybtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HPY",
+      "ForeignName": "hpyqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HPY",
+      "ForeignName": "hpyusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HSR",
+      "ForeignName": "hsrbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HSR",
+      "ForeignName": "hsrqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HSR",
+      "ForeignName": "hsrusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "HSR",
+      "ForeignName": "hsrzb",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ICX",
+      "ForeignName": "icxbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ICX",
+      "ForeignName": "icxqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ICX",
+      "ForeignName": "icxusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "INK",
+      "ForeignName": "inkbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "INK",
+      "ForeignName": "inkqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "INK",
+      "ForeignName": "inkusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "KAN",
+      "ForeignName": "kanbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "KAN",
+      "ForeignName": "kanqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "KAN",
+      "ForeignName": "kanusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "KNC",
+      "ForeignName": "kncbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "KNC",
+      "ForeignName": "kncqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "KNC",
+      "ForeignName": "kncusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "LBTC",
+      "ForeignName": "lbtcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "LBTC",
+      "ForeignName": "lbtcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "LBTC",
+      "ForeignName": "lbtcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "LTC",
+      "ForeignName": "ltcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "LTC",
+      "ForeignName": "ltcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "LTC",
+      "ForeignName": "ltcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "LTC",
+      "ForeignName": "ltczb",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MANA",
+      "ForeignName": "manabtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MANA",
+      "ForeignName": "manaqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MANA",
+      "ForeignName": "manausdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MCO",
+      "ForeignName": "mcobtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MCO",
+      "ForeignName": "mcoqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MCO",
+      "ForeignName": "mcousdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MITH",
+      "ForeignName": "mithbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MITH",
+      "ForeignName": "mithqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MITH",
+      "ForeignName": "mithusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MTL",
+      "ForeignName": "mtlbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MTL",
+      "ForeignName": "mtlqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "MTL",
+      "ForeignName": "mtlusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "NEO",
+      "ForeignName": "neobtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "NEO",
+      "ForeignName": "neoqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "NEO",
+      "ForeignName": "neousdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "OMG",
+      "ForeignName": "omgbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "OMG",
+      "ForeignName": "omgqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "OMG",
+      "ForeignName": "omgusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "PDX",
+      "ForeignName": "pdxqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "QTUM",
+      "ForeignName": "qtumbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "QTUM",
+      "ForeignName": "qtumqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "QTUM",
+      "ForeignName": "qtumusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "QTUM",
+      "ForeignName": "qtumzb",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "QUN",
+      "ForeignName": "qunbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "QUN",
+      "ForeignName": "qunqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "QUN",
+      "ForeignName": "qunusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "RCN",
+      "ForeignName": "rcnbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "RCN",
+      "ForeignName": "rcnqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "RCN",
+      "ForeignName": "rcnusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SAFE",
+      "ForeignName": "safebtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SAFE",
+      "ForeignName": "safeqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SAFE",
+      "ForeignName": "safeusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SBTC",
+      "ForeignName": "sbtcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SBTC",
+      "ForeignName": "sbtcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SBTC",
+      "ForeignName": "sbtcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SLT",
+      "ForeignName": "sltbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SLT",
+      "ForeignName": "sltqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SLT",
+      "ForeignName": "sltusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SNT",
+      "ForeignName": "sntbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SNT",
+      "ForeignName": "sntqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SNT",
+      "ForeignName": "sntusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SUB",
+      "ForeignName": "subbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SUB",
+      "ForeignName": "subqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "SUB",
+      "ForeignName": "subusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "TOPC",
+      "ForeignName": "topcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "TOPC",
+      "ForeignName": "topcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "TOPC",
+      "ForeignName": "topcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "TRUE",
+      "ForeignName": "truebtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "TRUE",
+      "ForeignName": "trueqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "TRUE",
+      "ForeignName": "trueusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "TV",
+      "ForeignName": "tvbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "TV",
+      "ForeignName": "tvqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "TV",
+      "ForeignName": "tvusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "UBTC",
+      "ForeignName": "ubtcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "UBTC",
+      "ForeignName": "ubtcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "UBTC",
+      "ForeignName": "ubtcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "USDT",
+      "ForeignName": "usdtqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XEM",
+      "ForeignName": "xembtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XEM",
+      "ForeignName": "xemqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XEM",
+      "ForeignName": "xemusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XLM",
+      "ForeignName": "xlmbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XLM",
+      "ForeignName": "xlmqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XLM",
+      "ForeignName": "xlmusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XRP",
+      "ForeignName": "xrpbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XRP",
+      "ForeignName": "xrpqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XRP",
+      "ForeignName": "xrpusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XRP",
+      "ForeignName": "xrpzb",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XUC",
+      "ForeignName": "xucbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XUC",
+      "ForeignName": "xucqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XWC",
+      "ForeignName": "xwcbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XWC",
+      "ForeignName": "xwcqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "XWC",
+      "ForeignName": "xwcusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ZB",
+      "ForeignName": "zbbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ZB",
+      "ForeignName": "zbqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ZB",
+      "ForeignName": "zbusdt",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ZRX",
+      "ForeignName": "zrxbtc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ZRX",
+      "ForeignName": "zrxqc",
+      "Exchange": "ZB"
+    },
+    {
+      "Symbol": "ZRX",
+      "ForeignName": "zrxusdt",
+      "Exchange": "ZB"
     }
   ]
 }

--- a/exchange-scrapers/scrapers/APIScraper.go
+++ b/exchange-scrapers/scrapers/APIScraper.go
@@ -56,6 +56,8 @@ func NewAPIScraper(exchange string, key string, secret string) APIScraper {
 		return NewLBankScraper()
 	case dia.GateIOExchange:
 		return NewGateIOScraper()
+	case dia.ZBExchange:
+		return NewZBScraper()
 	default:
 		return nil
 	}

--- a/exchange-scrapers/scrapers/ZBScraper.go
+++ b/exchange-scrapers/scrapers/ZBScraper.go
@@ -1,0 +1,212 @@
+package scrapers
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/diadata-org/api-golang/dia"
+	ws "github.com/gorilla/websocket"
+)
+
+var ZBSocketURL string = "wss://api.zb.cn:9999/websocket"
+
+type ZBSubscribe struct {
+	Event   string `json:"event"`
+	Channel string `json:"channel"`
+}
+
+type ZBTradeResponse struct {
+	DataType string `json:"dataType"`
+	Data     []struct {
+		Amount    string `json:"amount"`
+		Price     string `json:"price"`
+		Tid       int    `json:"tid"`
+		Date      int    `json:"date"`
+		Type      string `json:"type"`
+		TradeType string `json:"trade_type"`
+	} `json:"data"`
+	Channel string `json:"channel"`
+}
+
+type ZBScraper struct {
+	wsClient *ws.Conn
+	// signaling channels for session initialization and finishing
+	//initDone     chan nothing
+	shutdown     chan nothing
+	shutdownDone chan nothing
+	// error handling; to read error or closed, first acquire read lock
+	// only cleanup method should hold write lock
+	errorLock sync.RWMutex
+	error     error
+	closed    bool
+	// used to keep track of trading pairs that we subscribed to
+	pairScrapers map[string]*ZBPairScraper
+}
+
+// NewZBScraper returns a new ZBScraper for the given pair
+func NewZBScraper() *ZBScraper {
+
+	s := &ZBScraper{
+		shutdown:     make(chan nothing),
+		shutdownDone: make(chan nothing),
+		pairScrapers: make(map[string]*ZBPairScraper),
+		error:        nil,
+	}
+
+	var wsDialer ws.Dialer
+	SwConn, _, err := wsDialer.Dial(ZBSocketURL, nil)
+
+	if err != nil {
+		println(err.Error())
+	}
+
+	s.wsClient = SwConn
+	go s.mainLoop()
+	return s
+}
+
+// runs in a goroutine until s is closed
+func (s *ZBScraper) mainLoop() {
+
+	for true {
+
+		message := &ZBTradeResponse{}
+		if err := s.wsClient.ReadJSON(&message); err != nil {
+			println(err.Error())
+			break
+		}
+
+		for _, trade := range message.Data {
+			ps, ok := s.pairScrapers[strings.TrimSuffix(message.Channel, "_trades")]
+			if !ok {
+				log.Printf("unknown pair: %s", message.Channel)
+				continue
+			}
+
+			f64Price, err := strconv.ParseFloat(trade.Price, 64)
+			if err != nil {
+				log.Printf("error parsing price: %s", trade.Price)
+				continue
+			}
+
+			if trade.Type == "sell" {
+				f64Price = -f64Price
+			}
+
+			f64Volume, err := strconv.ParseFloat(trade.Amount, 64)
+			if err != nil {
+				log.Printf("error parsing volume: %s", trade.Price)
+				continue
+			}
+
+			t := &dia.Trade{
+				Symbol:         ps.Pair().Symbol,
+				Pair:           strings.TrimSuffix(message.Channel, "_trades"),
+				Price:          f64Price,
+				Volume:         f64Volume,
+				Time:           time.Unix(int64(trade.Date), 0),
+				ForeignTradeID: fmt.Sprint(trade.Tid),
+				Source:         dia.ZBExchange,
+			}
+			ps.chanTrades <- t
+		}
+	}
+}
+
+func (s *ZBScraper) cleanup(err error) {
+	s.errorLock.Lock()
+	defer s.errorLock.Unlock()
+
+	if err != nil {
+		s.error = err
+	}
+	s.closed = true
+
+	close(s.shutdownDone)
+}
+
+// Close closes any existing API connections, as well as channels of
+// PairScrapers from calls to ScrapePair
+func (s *ZBScraper) Close() error {
+
+	if s.closed {
+		return errors.New("ZBScraper: Already closed")
+	}
+
+	close(s.shutdown)
+	<-s.shutdownDone
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+	return s.error
+}
+
+// ScrapePair returns a PairScraper that can be used to get trades for a single pair from
+// this APIScraper
+func (s *ZBScraper) ScrapePair(pair dia.Pair) (PairScraper, error) {
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+
+	if s.error != nil {
+		return nil, s.error
+	}
+
+	if s.closed {
+		return nil, errors.New("ZBScraper: Call ScrapePair on closed scraper")
+	}
+
+	ps := &ZBPairScraper{
+		parent:     s,
+		pair:       pair,
+		chanTrades: make(chan *dia.Trade),
+	}
+
+	s.pairScrapers[pair.ForeignName] = ps
+
+	a := &ZBSubscribe{
+		Event:   "addChannel",
+		Channel: pair.ForeignName + "_trades",
+	}
+
+	if err := s.wsClient.WriteJSON(a); err != nil {
+		fmt.Println(err.Error())
+	}
+
+	return ps, nil
+}
+
+// ZBPairScraper implements PairScraper for ZB
+type ZBPairScraper struct {
+	parent     *ZBScraper
+	pair       dia.Pair
+	chanTrades chan *dia.Trade
+	closed     bool
+}
+
+// Close stops listening for trades of the pair associated with s
+func (ps *ZBPairScraper) Close() error {
+	return nil
+}
+
+// Channel returns a channel that can be used to receive trades
+func (ps *ZBPairScraper) Channel() chan *dia.Trade {
+	return ps.chanTrades
+}
+
+// Error returns an error when the channel Channel() is closed
+// and nil otherwise
+func (ps *ZBPairScraper) Error() error {
+	s := ps.parent
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+	return s.error
+}
+
+// Pair returns the pair this scraper is subscribed to
+func (ps *ZBPairScraper) Pair() dia.Pair {
+	return ps.pair
+}


### PR DESCRIPTION
Adds 206 coin pairs to the exchange scraper from the [ZB exchange](https://www.zb.com/) using their [websocket API](https://www.zb.com/i/developer/websocketApi).

Because they use a weird format for the pairs without a delimiter I had to first manually add an underscore and then remove `_trades` which is needed for their websocket API. To assist with adding the 206 coin pairs to [exchange-scrapers/config/exchange-scrapers.json](https://github.com/montanaflynn/api-golang/blob/3a037508570647c391af0b7d6b512573392368ce/exchange-scrapers/config/exchange-scrapers.json) I wrote a small program:

https://gist.github.com/montanaflynn/41d8ef164bc897bab7e53ddf9a12bbb1 